### PR TITLE
relative export path bug fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.11.2</version>
+            <version>0.12.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/org/dcache/simplenfs/LocalFileSystem.java
+++ b/src/main/java/org/dcache/simplenfs/LocalFileSystem.java
@@ -129,7 +129,8 @@ public class LocalFileSystem implements VirtualFileSystem {
         _root = root;
         assert (Files.exists(_root));
         for (FsExport export : exportIterable) {
-            Path exportRootPath = root.resolve(export.getPath());
+            String relativeExportPath = export.getPath().substring(1); // remove the opening '/'
+            Path exportRootPath = root.resolve(relativeExportPath);
             if (!Files.exists(exportRootPath)) {
                 Files.createDirectories(exportRootPath);
             }


### PR DESCRIPTION
SImpleNfsServer does not support relative exports within the root of the local file file system.
In addition, use fs4j-core-0.12.0-SNAPSHOT to get a bug fix for respecting GID and UID on creation.




Signed-off-by: svenin <odedsonin@gmail.com>
