### PR TITLE
fs: fix invalid stat when path is a symbolic link

### DIFF
--- a/src/main/java/org/dcache/simplenfs/LocalFileSystem.java
+++ b/src/main/java/org/dcache/simplenfs/LocalFileSystem.java
@@ -455,8 +455,8 @@ public class LocalFileSystem implements VirtualFileSystem {
             DosFileAttributes dosAttrs = (DosFileAttributes)attrs;
             stat.setGid(0);
             stat.setUid(0);
-            int type = dosAttrs.isDirectory() ? Stat.S_IFDIR : Stat.S_IFREG;
-            stat.setMode( type |(dosAttrs.isReadOnly()? 0600 : 0400));
+            int type = dosAttrs.isSymbolicLink() ? Stat.S_IFLNK : dosAttrs.isDirectory() ? Stat.S_IFDIR : Stat.S_IFREG;
+            stat.setMode( type |(dosAttrs.isReadOnly()? 0400 : 0600));
             stat.setNlink(1);
         }
 


### PR DESCRIPTION
This patch fix support for symbolic links on windows. (I actually look for an alternative to WinNFSD).