### PR TITLE
Handle special "dot" directories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.17.8</version>
+            <version>0.18.2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/org/dcache/simplenfs/LocalFileSystem.java
+++ b/src/main/java/org/dcache/simplenfs/LocalFileSystem.java
@@ -204,12 +204,18 @@ public class LocalFileSystem implements VirtualFileSystem {
     @Override
     public Inode lookup(Inode parent, String path) throws IOException {
         //TODO - several issues
-        //1. we might not deal with "." and ".." properly
         //2. we might accidentally allow composite paths here ("/dome/dir/down")
         //3. we dont actually check that the parent exists
         long parentInodeNumber = getInodeNumber(parent);
         Path parentPath = resolveInode(parentInodeNumber);
-        Path child = parentPath.resolve(path);
+        Path child;
+        if(path.equals(".")) {
+            child = parentPath;
+        } else if(path.equals("..")) {
+            child = parentPath.getParent();
+        } else {
+            child = parentPath.resolve(path);
+        }
         long childInodeNumber = resolvePath(child);
         return toFh(childInodeNumber);
     }


### PR DESCRIPTION
Had to use the server with OpenBSD NFS mount, which only supports some v3 variant, and it turned out unusable without this.